### PR TITLE
C2カバレッジ対応

### DIFF
--- a/src/test/java/nablarch/core/repository/di/config/externalize/AnnotationComponentDefinitionLoaderTest.java
+++ b/src/test/java/nablarch/core/repository/di/config/externalize/AnnotationComponentDefinitionLoaderTest.java
@@ -8,6 +8,7 @@ import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
 import nablarch.core.repository.test.ContextClassLoaderExchanger;
 import nablarch.core.repository.test.component.normal.TestComponent;
 import nablarch.core.repository.test.component.normal.TestInjectionComponent;
+import nablarch.core.repository.test.component.normal.TestMultipleConstructorComponent;
 import nablarch.core.repository.test.component.normal.TestNamingComponent;
 import nablarch.core.repository.test.component.normal.TestReferenceInjectionComponent;
 import nablarch.core.util.ClassTraversal;
@@ -24,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -56,6 +58,12 @@ public class AnnotationComponentDefinitionLoaderTest {
         assertNotNull(testComponent);
         assertEquals(TestComponent.class, testComponent.getClass());
 
+        // コンストラクタが複数あるコンポーネント
+        Object testMultipleConstructorComponent = container.getComponentByName(TestMultipleConstructorComponent.class.getName());
+        assertNotNull(testMultipleConstructorComponent);
+        assertEquals(TestMultipleConstructorComponent.class, testMultipleConstructorComponent.getClass());
+        assertNull(((TestMultipleConstructorComponent) testMultipleConstructorComponent).getComponent());
+
         // インナークラスのコンポーネント
         Object innerComponent = container.getComponentByName(TestComponent.TestInnerComponent.class.getName());
         assertNotNull(innerComponent);
@@ -82,6 +90,7 @@ public class AnnotationComponentDefinitionLoaderTest {
         assertThat(testInjectionComponent.getIntArrayConfig(), is(new int[]{1, 2, 3}));
         assertThat(testInjectionComponent.getLongConfig(), is(8L));
         assertTrue(testInjectionComponent.isBooleanConfig());
+        assertNull(testInjectionComponent.getDummy());
 
         // コンポーネント参照によるコンストラクタインジェクションのコンポーネント
         Object refInjectedComponent = container.getComponentByName(TestReferenceInjectionComponent.class.getName());

--- a/src/test/java/nablarch/core/repository/test/annotation/DummyAnnotation.java
+++ b/src/test/java/nablarch/core/repository/test/annotation/DummyAnnotation.java
@@ -1,0 +1,22 @@
+package nablarch.core.repository.test.annotation;
+
+import nablarch.core.repository.di.config.externalize.annotation.ComponentRef;
+import nablarch.core.repository.di.config.externalize.annotation.ConfigValue;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * コンストラクタの引数に付与されたアノテーションが{@link ComponentRef}か
+ * {@link ConfigValue}以外の場合何もしないパターンのテスト用アノテーション
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DummyAnnotation {
+
+    String value();
+}

--- a/src/test/java/nablarch/core/repository/test/component/normal/TestInjectionComponent.java
+++ b/src/test/java/nablarch/core/repository/test/component/normal/TestInjectionComponent.java
@@ -3,6 +3,7 @@ package nablarch.core.repository.test.component.normal;
 
 import nablarch.core.repository.di.config.externalize.annotation.ConfigValue;
 import nablarch.core.repository.di.config.externalize.annotation.SystemRepositoryComponent;
+import nablarch.core.repository.test.annotation.DummyAnnotation;
 
 @SystemRepositoryComponent
 public class TestInjectionComponent {
@@ -15,6 +16,7 @@ public class TestInjectionComponent {
     private final int[] intArrayConfig;
     private final long longConfig;
     private final boolean booleanConfig;
+    private final String dummy;
 
     public TestInjectionComponent(TestInjectionDummyComponent component
             , @ConfigValue("${config.value.string}") String stringConfig
@@ -22,7 +24,8 @@ public class TestInjectionComponent {
             , @ConfigValue("${config.value.integer}") int intConfig
             , @ConfigValue("${config.value.integer.array}") int[] intArrayConfig
             , @ConfigValue("${config.value.long}") long longConfig
-            , @ConfigValue("${config.value.boolean}") boolean booleanConfig) {
+            , @ConfigValue("${config.value.boolean}") boolean booleanConfig
+            , @DummyAnnotation("dummy") String dummy) {
         this.component = component;
         this.stringConfig = stringConfig;
         this.stringArrayConfig = stringArrayConfig;
@@ -30,6 +33,7 @@ public class TestInjectionComponent {
         this.intArrayConfig = intArrayConfig;
         this.longConfig = longConfig;
         this.booleanConfig = booleanConfig;
+        this.dummy = dummy;
     }
 
     public TestInjectionDummyComponent getComponent() {
@@ -58,5 +62,9 @@ public class TestInjectionComponent {
 
     public boolean isBooleanConfig() {
         return booleanConfig;
+    }
+
+    public String getDummy() {
+        return dummy;
     }
 }

--- a/src/test/java/nablarch/core/repository/test/component/normal/TestMultipleConstructorComponent.java
+++ b/src/test/java/nablarch/core/repository/test/component/normal/TestMultipleConstructorComponent.java
@@ -1,0 +1,22 @@
+package nablarch.core.repository.test.component.normal;
+
+
+import nablarch.core.repository.di.config.externalize.annotation.SystemRepositoryComponent;
+
+@SystemRepositoryComponent
+public class TestMultipleConstructorComponent {
+
+    private final TestComponent component;
+
+    public TestMultipleConstructorComponent() {
+        this.component = null;
+    }
+
+    public TestMultipleConstructorComponent(TestComponent component) {
+        this.component = component;
+    }
+
+    public TestComponent getComponent() {
+        return component;
+    }
+}


### PR DESCRIPTION
- 複数のコンストラクタを持つコンポーネントではコンストラクタインジェクションされないこと
- @ComponentRef、@ConfigValue以外のアノテーションがコンストラクタ引数についていても何もしないこと

のテストを追加