### PR TITLE
fix: 使っていないLoggerを削除

### DIFF
--- a/src/main/java/nablarch/core/repository/disposal/DisposableAdaptor.java
+++ b/src/main/java/nablarch/core/repository/disposal/DisposableAdaptor.java
@@ -1,8 +1,5 @@
 package nablarch.core.repository.disposal;
 
-import nablarch.core.log.Logger;
-import nablarch.core.log.LoggerManager;
-
 import java.io.Closeable;
 
 /**
@@ -14,8 +11,6 @@ import java.io.Closeable;
  * @author Tanaka Tomoyuki
  */
 public class DisposableAdaptor implements Disposable {
-    private static final Logger LOGGER = LoggerManager.get(DisposableAdaptor.class);
-
     private Closeable target;
 
     @Override


### PR DESCRIPTION
`DisposerAdaptor` を作っている最中にレビュー指摘でログ出力のコードを削除したのですが、そのときに `Logger` の宣言を消し忘れていました。