### PR TITLE
行カバレッジ未達部分の補完

### DIFF
--- a/src/test/java/nablarch/core/repository/di/DiContainerTest.java
+++ b/src/test/java/nablarch/core/repository/di/DiContainerTest.java
@@ -117,6 +117,35 @@ public class DiContainerTest {
     }
 
     @Test
+    public void testDump() {
+        XmlComponentDefinitionLoader loader = new XmlComponentDefinitionLoader(
+                "nablarch/core/repository/di/DiContainerTest/testDump.xml");
+        new DiContainer(loader);
+
+        OnMemoryLogWriter.assertLogContains("writer.appLog",
+                "definition loaded id = 0\n" +
+                "\t type = class nablarch.core.repository.di.test.Component5\n" +
+                "\t name = comp5\n" +
+                "\t component information = [nablarch.core.repository.di.config.BeanComponentCreator@",
+
+                "\t------------------- component ref ------------------\n" +
+                "\t------------------- component ref ------------------\n",
+
+                "definition loaded id = 1\n" +
+                "\t type = class nablarch.core.repository.di.test.Component6\n" +
+                "\t name = comp6\n" +
+                "\t component information = [nablarch.core.repository.di.config.BeanComponentCreator@",
+
+                "\t------------------- component ref ------------------\n" +
+                "\t property name = interface1\n" +
+                "\t target id = -1\n" +
+                "\t component name = null\n" +
+                "\t required type = interface nablarch.core.repository.di.test.Interface1\n" +
+                "\n" +
+                "\t------------------- component ref ------------------\n");
+    }
+
+    @Test
     public void testLoad() throws Throwable {
         XmlComponentDefinitionLoader loader = new XmlComponentDefinitionLoader(
                 "nablarch/core/repository/di/DiContainerTest/testLoad.xml");

--- a/src/test/resources/log.properties
+++ b/src/test/resources/log.properties
@@ -10,5 +10,5 @@ writer.appLog.formatter.format=$logLevel$ $loggerName$ $message$$information$$st
 
 availableLoggersNamesOrder=ROOT
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=TRACE
 loggers.ROOT.writerNames=stdout,appLog

--- a/src/test/resources/nablarch/core/repository/di/DiContainerTest/testDump.xml
+++ b/src/test/resources/nablarch/core/repository/di/DiContainerTest/testDump.xml
@@ -1,0 +1,9 @@
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration component-configuration.xsd">
+
+  <component name="comp5" class="nablarch.core.repository.di.test.Component5" />
+  <component name="comp6" class="nablarch.core.repository.di.test.Component6" />
+
+</component-configuration>


### PR DESCRIPTION
テスト時のログレベルがDEBUGだったためdump()メソッドが実行されずカバレッジが落ちていたので、TRACEレベルで動くようにしてテストケースを追加