### PR TITLE
コンポーネント定義から存在しない環境依存値を参照した場合に例外を送出する

### DIFF
--- a/src/main/java/nablarch/core/repository/di/config/LiteralExpressionUtil.java
+++ b/src/main/java/nablarch/core/repository/di/config/LiteralExpressionUtil.java
@@ -10,11 +10,6 @@ import java.util.regex.Pattern;
 
 /**
  * リテラル表現を解決するユーティリティクラス。
- * リテラル表現に合致する環境依存値がDIコンテナから取得できない場合、例外が発生する。
- * 後方互換性を維持するするため、環境依存値{@literal "nablarch.diContainer.allowEmptyValue"}に
- * {@code true}を設定することで、リテラル表現に合致する環境依存値が取得できない場合にも処理を続行する。
- * その場合、リテラル表現の解決は行われず ${hoge} のようなリテラル表現がそのまま設定値として採用される。
- * {@literal "nablarch.diContainer.allowEmptyValue"}の後方互換性維持以外の目的での使用は推奨しない。
  * @author Koichi Asano
  */
 public final class LiteralExpressionUtil {
@@ -104,16 +99,19 @@ public final class LiteralExpressionUtil {
 
     /**
      * リテラル表現に合致する環境依存値が取得できないことを許容するか。
+     * {@link LiteralExpressionUtil#resolveVariable(DiContainer, String)}では
+     * リテラル表現に合致する環境依存値がDIコンテナから取得できない場合、例外が発生する。
+     * 後方互換性を維持するするため、環境依存値{@literal "nablarch.diContainer.allowEmptyValue"}に
+     * {@code true}を設定することで、リテラル表現に合致する環境依存値が取得できない場合にも処理を続行する。
+     * その場合、リテラル表現の解決は行われず ${hoge} のようなリテラル表現がそのまま設定値として採用される。
+     * {@literal "nablarch.diContainer.allowEmptyValue"}の後方互換性維持以外の目的での使用は推奨しない。
      * @param container DIコンテナ
      * @return 許容する場合 {@code true} 、許容しない場合 {@code false}
      */
     private static boolean isAllowEmptyValue(DiContainer container) {
-        Object allowEmptyValueSetting = container.getComponentByName("nablarch.diContainer.allowEmptyValue");
-        boolean allowEmptyValue = false;
-        if (allowEmptyValueSetting instanceof String) {
-            allowEmptyValue = Boolean.parseBoolean((String) allowEmptyValueSetting);
-        }
-        return allowEmptyValue;
+        Object allowEmptyValue = container.getComponentByName("nablarch.diContainer.allowEmptyValue");
+        return allowEmptyValue instanceof String
+                && Boolean.parseBoolean((String) allowEmptyValue);
     }
 
     /**

--- a/src/test/java/nablarch/core/repository/di/DiContainerTest.java
+++ b/src/test/java/nablarch/core/repository/di/DiContainerTest.java
@@ -833,7 +833,7 @@ public class DiContainerTest {
             DiContainer container = new DiContainer(loader);
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("recursive referenced was found."));
         }
     }
 
@@ -845,7 +845,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("recursive referenced was found."));
         }
     }
 
@@ -858,7 +858,7 @@ public class DiContainerTest {
             diContainer.getComponentByName("comp1");
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("recursive referenced was found."));
         }
     }
 
@@ -884,6 +884,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
+            assertThat(e.getCause().getMessage(), containsString("component name was duplicated."));
         }
 
     }
@@ -908,7 +909,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("property not found in  class."));
         }
     }
 
@@ -920,7 +921,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("component definition load failed."));
         }
     }
 
@@ -968,7 +969,8 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("component class load failed."));
+            assertThat(e.getCause().getCause(), CoreMatchers.<Throwable>instanceOf(ClassNotFoundException.class));
         }
     }
 
@@ -980,7 +982,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("property value was not found."));
         }
     }
 
@@ -993,7 +995,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("map entry must have key value."));
         }
     }
 
@@ -1005,7 +1007,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getCause().getMessage(), containsString("map entry must have key value."));
         }
     }
 
@@ -1017,7 +1019,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("property value was not found."));
         }
     }
 
@@ -1029,7 +1031,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("property value was not found."));
         }
     }
 
@@ -1041,7 +1043,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("property value was not found."));
         }
     }
 
@@ -1075,7 +1077,7 @@ public class DiContainerTest {
             DiContainer container = new DiContainer(loader);
             fail("コンポーネントファクトリ間で循環参照がある場合、例外が発生するはず");
         } catch (ContainerProcessException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("recursive referenced was found."));
         }
     }
 
@@ -1101,7 +1103,7 @@ public class DiContainerTest {
             container.getComponentById(-1);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-            // OK
+            assertThat(e.getMessage(), containsString("component id was not found."));
         }
     }
 
@@ -1125,7 +1127,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                // OK
+                assertThat(e.getMessage(), containsString("property type was not supported."));
             }
         }
 
@@ -1136,7 +1138,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                // OK
+                assertThat(e.getMessage(), containsString("property value conversion failed."));
             }
         }
 
@@ -1148,7 +1150,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                // OK
+                assertThat(e.getMessage(), containsString("property value conversion failed."));
             }
         }
 
@@ -1159,7 +1161,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                // OK
+                assertThat(e.getMessage(), containsString("property type was not supported."));
             }
         }
     }
@@ -1173,7 +1175,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-
+            assertThat(e.getMessage(), containsString("list entry component was not found."));
         }
 
     }
@@ -1186,7 +1188,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-
+            assertThat(e.getMessage(), containsString("map entry key component name was not found."));
         }
 
     }
@@ -1199,7 +1201,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-
+            assertThat(e.getMessage(), containsString("map entry value component name was not found."));
         }
     }
 
@@ -1222,7 +1224,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ContainerProcessException e) {
-
+                assertThat(e.getMessage(), containsString("component instantiation failed."));
             }
         }
         
@@ -1233,7 +1235,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ContainerProcessException e) {
-
+                assertThat(e.getMessage(), containsString("component instantiation failed."));
             }
         }
     }
@@ -1248,7 +1250,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ContainerProcessException e) {
-
+                assertThat(e.getCause().getMessage(), containsString("map entry must have key value."));
             }
         }
 
@@ -1258,7 +1260,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-
+            assertThat(e.getCause().getMessage(), containsString("map entry must have key value."));
         }
     }
 

--- a/src/test/java/nablarch/core/repository/di/DiContainerTest.java
+++ b/src/test/java/nablarch/core/repository/di/DiContainerTest.java
@@ -512,6 +512,7 @@ public class DiContainerTest {
             fail();
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("directory not found."));
+            assertThat(e.getMessage(), containsString("NonExists"));
         }
         
         /*
@@ -680,6 +681,7 @@ public class DiContainerTest {
             fail();
         } catch (IllegalStateException e) {
             assertThat(e.getMessage(), containsString("directory not found."));
+            assertThat(e.getMessage(), containsString("nonExists"));
         }
         
 
@@ -833,7 +835,7 @@ public class DiContainerTest {
             DiContainer container = new DiContainer(loader);
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("recursive referenced was found."));
+            assertThat(e.getMessage(), containsString("recursive referenced was found. component name = [comp1]"));
         }
     }
 
@@ -845,7 +847,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("recursive referenced was found."));
+            assertThat(e.getMessage(), containsString("recursive referenced was found. component name = [comp1]"));
         }
     }
 
@@ -858,7 +860,7 @@ public class DiContainerTest {
             diContainer.getComponentByName("comp1");
             fail("例外が発生するはず。");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("recursive referenced was found."));
+            assertThat(e.getMessage(), containsString("recursive referenced was found. component name = [comp1]"));
         }
     }
 
@@ -884,7 +886,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getCause().getMessage(), containsString("component name was duplicated."));
+            assertThat(e.getCause().getMessage(), containsString("component name was duplicated. name = comp1"));
         }
 
     }
@@ -909,7 +911,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getCause().getMessage(), containsString("property not found in  class."));
+            assertThat(e.getCause().getMessage(), containsString("property not found in  class. propertyName = prop3, className = nablarch.core.repository.di.test.Component4"));
         }
     }
 
@@ -982,7 +984,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getCause().getMessage(), containsString("property value was not found."));
+            assertThat(e.getCause().getMessage(), containsString("property value was not found. propertyName = prop1"));
         }
     }
 
@@ -1019,7 +1021,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getMessage(), containsString("property value was not found."));
+            assertThat(e.getMessage(), containsString("property value was not found. parameter = ${test.prop}"));
         }
     }
 
@@ -1031,7 +1033,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getMessage(), containsString("property value was not found."));
+            assertThat(e.getMessage(), containsString("property value was not found. parameter = ${test.prop}"));
         }
     }
 
@@ -1043,7 +1045,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ConfigurationLoadException e) {
-            assertThat(e.getMessage(), containsString("property value was not found."));
+            assertThat(e.getMessage(), containsString("property value was not found. parameter = ${test.prop}"));
         }
     }
 
@@ -1055,6 +1057,7 @@ public class DiContainerTest {
         DiContainer container = new DiContainer(loader);
         Component1 comp1 = container.getComponentByName("comp1");
         assertThat(comp1.getProp1(), is("${test.prop}"));
+        OnMemoryLogWriter.assertLogContains("writer.appLog", "WARN ROOT property value was not found. parameter = ${test.prop}");
     }
 
     @Test
@@ -1077,7 +1080,7 @@ public class DiContainerTest {
             DiContainer container = new DiContainer(loader);
             fail("コンポーネントファクトリ間で循環参照がある場合、例外が発生するはず");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("recursive referenced was found."));
+            assertThat(e.getMessage(), containsString("recursive referenced was found. component name = [ref1]"));
         }
     }
 
@@ -1103,7 +1106,7 @@ public class DiContainerTest {
             container.getComponentById(-1);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("component id was not found."));
+            assertThat(e.getMessage(), containsString("component id was not found. component id = [-1]"));
         }
     }
 
@@ -1127,7 +1130,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                assertThat(e.getMessage(), containsString("property type was not supported."));
+                assertThat(e.getMessage(), containsString("property type was not supported. class name = nablarch.core.repository.di.test.Component2"));
             }
         }
 
@@ -1138,7 +1141,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                assertThat(e.getMessage(), containsString("property value conversion failed."));
+                assertThat(e.getMessage(), containsString("property value conversion failed. class name = [I ,value = a"));
             }
         }
 
@@ -1150,7 +1153,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                assertThat(e.getMessage(), containsString("property value conversion failed."));
+                assertThat(e.getMessage(), containsString("property value conversion failed. class name = [Ljava.lang.Integer; ,value = a"));
             }
         }
 
@@ -1161,7 +1164,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ConfigurationLoadException e) {
-                assertThat(e.getMessage(), containsString("property type was not supported."));
+                assertThat(e.getMessage(), containsString("property type was not supported. class name = [J"));
             }
         }
     }
@@ -1175,7 +1178,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("list entry component was not found."));
+            assertThat(e.getMessage(), containsString("list entry component was not found.name = outComponent"));
         }
 
     }
@@ -1188,7 +1191,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("map entry key component name was not found."));
+            assertThat(e.getMessage(), containsString("map entry key component name was not found. name = key-component"));
         }
 
     }
@@ -1201,7 +1204,7 @@ public class DiContainerTest {
             new DiContainer(loader);
             fail("例外が発生するはず");
         } catch (ContainerProcessException e) {
-            assertThat(e.getMessage(), containsString("map entry value component name was not found."));
+            assertThat(e.getMessage(), containsString("map entry value component name was not found. name = component2"));
         }
     }
 
@@ -1224,7 +1227,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ContainerProcessException e) {
-                assertThat(e.getMessage(), containsString("component instantiation failed."));
+                assertThat(e.getMessage(), containsString("component instantiation failed. component class name = class nablarch.core.util.FileUtil"));
             }
         }
         
@@ -1235,7 +1238,7 @@ public class DiContainerTest {
                 new DiContainer(loader);
                 fail("例外が発生するはず");
             } catch (ContainerProcessException e) {
-                assertThat(e.getMessage(), containsString("component instantiation failed."));
+                assertThat(e.getMessage(), containsString("component instantiation failed. component class name = class nablarch.core.repository.di.test.DefaultConstructorLessObject"));
             }
         }
     }


### PR DESCRIPTION
#24 の指摘対応。
#24 はクローズしてしまったので新しいPRを作成しました。

https://github.com/nablarch/nablarch-core-repository/pull/24/files#r579024102
IDEが自動で整形していました。次回から気をつけます。

https://github.com/nablarch/nablarch-core-repository/pull/24/files#r579025032
`isAllowEmptyValue` に移動しました。

https://github.com/nablarch/nablarch-core-repository/pull/24/files#r579030213
`value == null` と `isAllowEmptyValue(container)` は一緒には評価出来ません。
&&でつないでしまうとelseの条件が`value != null || !isAllowEmptyValue(container)` になってしまいます。
`value == null` の場合に `isAllowEmptyValue(container)` の評価によって分岐させるので入れ子になります。

https://github.com/nablarch/nablarch-core-repository/pull/24/files#r579031566
`allowEmptyValue instanceof String && Boolean.parseBoolean((String) allowEmptyValue)` で事足りることに気づいたのでそうしました。

https://github.com/nablarch/nablarch-core-repository/pull/24/files#r579032954
既存がExceptionの型だけでOKにしていたので倣いましたが適切でないので、それぞれテストケースに合わせたメッセージでアサートするよう既存部分含めて修正しました。