### PR TITLE
 不要なIF文を削除

### DIFF
--- a/src/main/java/nablarch/core/repository/di/DiContainer.java
+++ b/src/main/java/nablarch/core/repository/di/DiContainer.java
@@ -28,10 +28,10 @@ import nablarch.core.util.annotation.Published;
 
 
 /**
- * DIコンテナの機能を実現するクラス。
+ * DIコンテナの機能を実現するクラス。<br/>
  *
  * staticプロパティへのインジェクションは行われない。
- * インジェクションの対象となるプロパティがstaticである場合、例外が発生する。
+ * インジェクションの対象となるプロパティがstaticである場合、例外が発生する。<br/>
  *
  * 後方互換性を維持するするため、システムプロパティ{@literal "nablarch.diContainer.allowStaticInjection"}に
  * {@code true}を設定することで、staticプロパティへのインジェクションを許可できる。
@@ -72,7 +72,7 @@ public class DiContainer implements ObjectLoader {
     /**
      * 循環参照の情報を保持するための参照スタック。
      */
-    private ReferenceStack refStack = new ReferenceStack();
+    private final ReferenceStack refStack = new ReferenceStack();
 
     /** staticプロパティへのインジェクションを許容するかどうか。 */
     private final boolean allowStaticInjection;
@@ -130,7 +130,7 @@ public class DiContainer implements ObjectLoader {
     /**
      * コンポーネント定義のローダ
      */
-    private ComponentDefinitionLoader loader;
+    private final ComponentDefinitionLoader loader;
 
     /**
      * コンポーネントIDの最大値。
@@ -414,7 +414,7 @@ public class DiContainer implements ObjectLoader {
     }
 
     /**
-     * オブジェクトに対してインジェクションを実行する。
+     * オブジェクトに対してインジェクションを実行する。<br/>
      *
      * この際、オブジェクトが作成されていない場合、コンポーネントの作成も行う。
      *

--- a/src/main/java/nablarch/core/repository/di/DiContainer.java
+++ b/src/main/java/nablarch/core/repository/di/DiContainer.java
@@ -28,11 +28,11 @@ import nablarch.core.util.annotation.Published;
 
 
 /**
- * DIコンテナの機能を実現するクラス。<br/>
- *
+ * DIコンテナの機能を実現するクラス。
+ *<p>
  * staticプロパティへのインジェクションは行われない。
- * インジェクションの対象となるプロパティがstaticである場合、例外が発生する。<br/>
- *
+ * インジェクションの対象となるプロパティがstaticである場合、例外が発生する。
+ *</p>
  * 後方互換性を維持するするため、システムプロパティ{@literal "nablarch.diContainer.allowStaticInjection"}に
  * {@code true}を設定することで、staticプロパティへのインジェクションを許可できる。
  * 後方互換性維持以外の目的での使用は推奨しない。
@@ -414,10 +414,10 @@ public class DiContainer implements ObjectLoader {
     }
 
     /**
-     * オブジェクトに対してインジェクションを実行する。<br/>
-     *
+     * オブジェクトに対してインジェクションを実行する。
+     *<p>
      * この際、オブジェクトが作成されていない場合、コンポーネントの作成も行う。
-     *
+     *</p>
      * @param holder コンポーネントホルダ
      */
     private void completeInject(ComponentHolder holder) {

--- a/src/main/java/nablarch/core/repository/di/DiContainer.java
+++ b/src/main/java/nablarch/core/repository/di/DiContainer.java
@@ -319,13 +319,8 @@ public class DiContainer implements ObjectLoader {
             nameIndex.put(def.getName(), holder);
         }
 
-        if (def.getClass() != null) {
-            if (!def.isUseIdOnly()) {
-                registerTypes(def, holder);
-            }
-        } else {
-            // 設定ファイルで落とすため、通常ここには到達しない。
-            throw new ContainerProcessException("component class was not specified");
+        if (!def.isUseIdOnly()) {
+            registerTypes(def, holder);
         }
     }
 

--- a/src/main/java/nablarch/core/repository/di/DiContainer.java
+++ b/src/main/java/nablarch/core/repository/di/DiContainer.java
@@ -32,7 +32,7 @@ import nablarch.core.util.annotation.Published;
  *<p>
  * staticプロパティへのインジェクションは行われない。
  * インジェクションの対象となるプロパティがstaticである場合、例外が発生する。
- *</p>
+ *<p>
  * 後方互換性を維持するするため、システムプロパティ{@literal "nablarch.diContainer.allowStaticInjection"}に
  * {@code true}を設定することで、staticプロパティへのインジェクションを許可できる。
  * 後方互換性維持以外の目的での使用は推奨しない。
@@ -417,7 +417,7 @@ public class DiContainer implements ObjectLoader {
      * オブジェクトに対してインジェクションを実行する。
      *<p>
      * この際、オブジェクトが作成されていない場合、コンポーネントの作成も行う。
-     *</p>
+     *
      * @param holder コンポーネントホルダ
      */
     private void completeInject(ComponentHolder holder) {

--- a/src/main/java/nablarch/core/repository/di/DiContainer.java
+++ b/src/main/java/nablarch/core/repository/di/DiContainer.java
@@ -234,7 +234,7 @@ public class DiContainer implements ObjectLoader {
         }
 
         // 初期化対象クラスを初期化する。
-        ApplicationInitializer initializer = (ApplicationInitializer) this.getComponentByName("initializer");
+        ApplicationInitializer initializer = this.getComponentByName("initializer");
         if (initializer != null) {
             initializer.initialize();
         }


### PR DESCRIPTION
- [2018年に外部から来たPR](https://github.com/nablarch/nablarch-core-repository/pull/13)の対応で、 不要なIF文を削除しました。

【経緯】
まず、もとの実装ではgetClassメソッドの結果を判定しているが、常にtrueになるため正しい実装ではない。
2018年に外部から来たPRに指摘があったgetTypeメソッドを呼ぶとComponentDefinition生成時に指定するtype（最後の引数）を返すが、typeにnullが入ってくるケースが無いためこの分岐自体必要ないと判断。

- Inspection対応を行いました。